### PR TITLE
Edit: accounts, users - social login logic, user_game_category, nickn…

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -22,7 +22,7 @@ class ProfileAPIView(APIView):
 
     # 유효성 검사 정규식 패턴
     EMAIL_PATTERN = re.compile(r'^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$')
-    NICKNAME_PATTERN = re.compile(r"^[a-zA-Z0-9]{8,30}$")
+    NICKNAME_PATTERN = re.compile(r"^[a-zA-Z0-9]{4,30}$")
 
     def get(self, request, user_pk):
         user = get_object_or_404(get_user_model(), pk=user_pk, is_active=True)
@@ -69,7 +69,7 @@ class ProfileAPIView(APIView):
         # 닉네임이 유효하지 않거나 다른 유저의 이메일로 수정하려고 할 경우 error
         elif not self.NICKNAME_PATTERN.match(nickname):
             return Response(
-                {"error_message": "올바른 nickname을 입력해주세요."},
+                {"error_message": "올바른 nickname을 입력해주세요. 4자 이상 30자 이하의 영숫자입니다."},
                 status=status.HTTP_400_BAD_REQUEST
             )
         elif get_user_model().objects.filter(nickname=nickname).exists():
@@ -79,10 +79,11 @@ class ProfileAPIView(APIView):
             )
         
         # 관심 게임 카테고리
-        categories = request.data.get("game_category", [])
+        categories = request.data.get("game_category", '')
+        categories = categories.split(',')
         if categories:
             game_categories = GameCategory.objects.filter(name__in=categories)
-            if not game_categories:
+            if not game_categories.exists():
                 return Response(
                     {"error_message": "올바른 game category를 입력해주세요."},
                     status=status.HTTP_400_BAD_REQUEST
@@ -169,14 +170,14 @@ def user_tech_list(request):
 @api_view(["GET"])
 def check_nickname(request):
     # 유효성 검사 정규식 패턴
-    NICKNAME_PATTERN = re.compile(r"^[a-zA-Z0-9]{8,30}$")
+    NICKNAME_PATTERN = re.compile(r"^[a-zA-Z0-9]{4,30}$")
 
     nickname = request.data.get('nickname', None)
         
     # 닉네임이 유효하지 않거나 다른 유저의 이메일로 수정하려고 할 경우 error
     if not NICKNAME_PATTERN.match(nickname):
         return Response(
-            {"error_message": "올바른 nickname을 입력해주세요."},
+            {"error_message": "올바른 nickname을 입력해주세요. 4자 이상 30자 이하의 영숫자입니다."},
             status=status.HTTP_400_BAD_REQUEST
         )
     elif get_user_model().objects.filter(nickname=nickname).exists():


### PR DESCRIPTION
accounts 앱

1. 소셜 로그인 로직 수정
- 기존 테스트용 social_signinup 함수 주석 처리
- SignUpAPIView의 post 메서드에 토큰 발급 로직 병합
- 로그인 타입 별로 비밀번호 유효성 검사 및 데이터 추가하는 과정 분기 처리
- 로그인 타입 데이터 저장하도록 로직 추가

2. 닉네임 패턴 수정(기존: 8-30자 영숫자 -> 4-30자 영숫자)
3. 유저 관심 카테고리 오류 수정

users 앱

1. 닉네임 패턴 수정(기존: 8-30자 영숫자 -> 4-30자 영숫자)
2. 유저 관심 카테고리 오류 수정

