### PR TITLE
Edit:games, users 리뷰 시리얼라이저, 페이지 네이션, 검색 오류 제거, 게임팩 기준 수정

### DIFF
--- a/games/serializers.py
+++ b/games/serializers.py
@@ -85,7 +85,6 @@ class ReviewSerializer(serializers.ModelSerializer):
     game_id = serializers.IntegerField(source='game.id', read_only=True)
     author_name = serializers.CharField(
         source='author.nickname', read_only=True)
-    src = serializers.ImageField(source='author.image', read_only=True)
     like_count = serializers.SerializerMethodField()
     dislike_count = serializers.SerializerMethodField()
     user_is_like = serializers.SerializerMethodField()
@@ -93,7 +92,7 @@ class ReviewSerializer(serializers.ModelSerializer):
     class Meta:
         model = Review
         fields = [
-            'id','author_name','src','like_count','dislike_count','user_is_like',
+            'id','author_name','like_count','dislike_count','user_is_like',
             'content','star','difficulty','is_visible','created_at','updated_at',
             'author_id','game_id',
         ]
@@ -116,13 +115,6 @@ class ReviewSerializer(serializers.ModelSerializer):
         review_like = ReviewsLike.objects.filter(review=obj, user=user).first()
         # 리뷰 상태가 존재하면 그 값을 반환, 없으면 0을 반환
         return review_like.is_like if review_like else 0
-        """ # 사용자가 해당 리뷰에 남긴 상태를 조회
-        if user:
-            review_like = ReviewsLike.objects.filter(review=obj, user=user).first()
-            # 리뷰 상태가 존재하면 그 값을 반환, 없으면 0을 반환
-            return review_like.is_like if review_like else 0
-        else:
-            return 0 """
 
 
 class ScreenshotSerializer(serializers.ModelSerializer):

--- a/spartagames/pagination.py
+++ b/spartagames/pagination.py
@@ -1,7 +1,7 @@
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
-class CustomPagination(PageNumberPagination):
+class ReviewCustomPagination(PageNumberPagination):
     page_size = 4  # 기본 페이지 크기
     page_size_query_param = 'limit'  # 클라이언트가 페이지 크기를 제어
     page_query_param = 'page'  # 페이지 번호 쿼리 파라미터
@@ -33,3 +33,9 @@ class CustomPagination(PageNumberPagination):
                 "all_games": data,  # 페이지네이션된 데이터
             },
         })
+
+class CustomPagination(PageNumberPagination):
+    page_size = 20  # 기본 페이지 크기
+    page_size_query_param = 'limit'  # 클라이언트가 페이지 크기를 제어
+    page_query_param = 'page'  # 페이지 번호 쿼리 파라미터
+    max_page_size = 100  # 최대 허용 페이지 크기


### PR DESCRIPTION
1.리뷰 시리얼라이저 src 제거(FE 요청)
2.리뷰 페이지네이션과 users에서 사용하는 페이지네이션 구분을 위해 리뷰 페이지네이션을 구분함
3.검색 로직중 exists() 유저 정보 없을때도 검사->오류 발생, 유저 정보 있을때만 나타나게 변경 
4.게임팩 기준 변경 : 스타 높은순, 최신순으로 기본 즐겨찾기를 채우고 비어 있을 시 유저 관심 카테고리 스타, 최신순으로 채워서 4개를 맞춰 보내줌