### PR TITLE
Edit: change logic of recommendedposts

### DIFF
--- a/teambuildings/views.py
+++ b/teambuildings/views.py
@@ -149,9 +149,9 @@ class TeamBuildPostAPIView(APIView):
                 if curr_cnt < 4:
                     # 마감 임박 팀빌딩 모집글 리스트
                     # 맞춤 팀빌딩 모집글에 있는 경우 제외 (.exclude(pk__in=[row.pk for row in _qs]))
-                    # (4 - 맞춤 팀빌딩 모집글 개수) 개수만큼 가져옴 ([:4 - curr_cnt])
                     # 마감 임박 팀빌딩 모집글 리스트는 본래 마감기한 순으로 정렬됨 (.order_by('deadline'))
-                    _extra_qs = recommendedposts.exclude(pk__in=[row.pk for row in _qs])[:4 - curr_cnt].order_by('deadline')
+                    # (4 - 맞춤 팀빌딩 모집글 개수) 개수만큼 가져옴 ([:4 - curr_cnt])
+                    _extra_qs = recommendedposts.exclude(pk__in=[row.pk for row in _qs]).order_by('deadline')[:4 - curr_cnt]
                     # 최종적으로 4개로 제한 (이중 체크)
                     recommendedposts = (_qs | _extra_qs)[:4]
                 else:


### PR DESCRIPTION
팀빌딩 추천글 목록 로직 수정

- 마감되지 않은 글들을 불러오도록 수정
- 로그인 유저의 프로필 기반 맞춤 팀빌딩 모집글을 1순위, 마감 임박 팀빌딩 모집글을 2순위로 함
- 1순위 글 개수가 4개 미만일 경우, 1순위 글과 중복되지 않은 2순위 글로 부족한 개수를 채움