### PR TITLE
Add: users - teambuild_posts

### DIFF
--- a/teambuildings/pagination.py
+++ b/teambuildings/pagination.py
@@ -10,6 +10,13 @@ class TeamBuildPostPagination(PageNumberPagination):
     max_page_size = 100  # 허용되는 최대 페이지 크기
 
 
+class MyTeamBuildPostPagination(PageNumberPagination):
+    page_size = 3  # 기본 페이지 크기 설정
+    page_size_query_param = 'limit'  # 클라이언트가 페이지 크기를 조정할 수 있는 파라미터
+    page_query_param = 'page'  # 페이지 번호를 지정하는 쿼리 파라미터
+    max_page_size = 100  # 허용되는 최대 페이지 크기
+
+
 class TeamBuildProfileListPagination(PageNumberPagination):
     page_size = 12
     page_size_query_param = 'limit'

--- a/users/urls.py
+++ b/users/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path("api/<int:user_id>/likes/", views.like_games, name="like_games"),
     path("api/<int:user_id>/gamepacks/", views.gamepacks, name="gamepacks"),    # 2024-12-30 유저 페이지 게임팩 API 복구
     path("api/<int:user_id>/recent/", views.recently_played_games, name="recent_played_games"),
+    path("api/<int:user_id>/teambuildposts/", views.teambuild_posts, name="teambuild_posts"),
     # ---------- Web---------- #
     # path("<int:user_pk>/", views.profile_page, name='profile_page'),
 ]


### PR DESCRIPTION
내 프로필 페이지 (혹은 상대방의 프로필 페이지) 에서 '팀빌딩 모집글' 을 불러올 수 있는 기능 추가
`/users/api/<int:user_id>/teambuildposts/`

페이지네이션 적용 (기본 크기: 3)
내 프로필 페이지를 볼 경우 모집중, 모집마감 모두 표시되고
상대방의 프로필 페이지를 볼 경우 모집중만 보이도록 함

작성일시 기준 최신순 정렬