### PR TITLE
perf: 관리자 게임 등록 목록 N+1 제거

### DIFF
--- a/qnas/querysets.py
+++ b/qnas/querysets.py
@@ -1,0 +1,22 @@
+"""
+qnas 앱 목록 조회용 queryset 최적화 헬퍼.
+"""
+from django.db.models import Prefetch
+
+from .models import GameRegisterLog
+
+
+def with_game_register_list_optimizations(qs):
+    """
+    관리자 게임 등록 목록(GameRegisterListSerializer)용 최적화.
+    - maker(FK) select_related
+    - category(M2M) prefetch_related
+    - logs_game(역참조)는 최신순으로 Prefetch (시리얼라이저에서 상위 2개만 사용)
+    """
+    return qs.select_related("maker").prefetch_related(
+        "category",
+        Prefetch(
+            "logs_game",
+            queryset=GameRegisterLog.objects.order_by("-created_at"),
+        ),
+    )

--- a/qnas/serializers.py
+++ b/qnas/serializers.py
@@ -39,5 +39,6 @@ class GameRegisterListSerializer(serializers.ModelSerializer):
         return [{"id": category.id, "name": category.name,} for category in obj.category.all()]
     
     def get_game_register_logs(self, obj):
-        # 로그 리스트를 반환
-        return [{"created_at": log.created_at, "content": log.content} for log in obj.logs_game.filter(game=obj).order_by("-created_at")][:2]
+        # 로그 리스트를 반환 (prefetch된 logs_game 캐시를 사용하기 위해 .all() 사용)
+        # Prefetch에서 -created_at 정렬을 적용하므로 앞에서 2개가 최신 로그다.
+        return [{"created_at": log.created_at, "content": log.content} for log in obj.logs_game.all()[:2]]

--- a/qnas/views.py
+++ b/qnas/views.py
@@ -21,6 +21,7 @@ from .models import (
 from .pagination import (
     GameRegisterListPagination,
 )
+from .querysets import with_game_register_list_optimizations
 from .serializers import (
     QnAPostListSerializer,
     CategorySerializer,
@@ -206,7 +207,7 @@ def game_register_list(request):
     if keyword_q:
         query &= Q(title__icontains=keyword_q) | Q(maker__nickname__icontains=keyword_q)
     
-    rows = Game.objects.filter(query).distinct()
+    rows = with_game_register_list_optimizations(Game.objects.filter(query).distinct())
 
     # 페이지네이션
     paginator = GameRegisterListPagination()


### PR DESCRIPTION
- qnas/querysets.py 추가: maker select_related + category/logs_game prefetch(Prefetch 최신순)

- GameRegisterListSerializer.get_game_register_logs를 prefetch 캐시 사용(.all()[:2])으로 변경

- game_register_list에 with_game_register_list_optimizations 적용