### PR TITLE
Refact/teambuildings write optimize

### DIFF
--- a/teambuildings/views.py
+++ b/teambuildings/views.py
@@ -1392,24 +1392,19 @@ class TeamBuildProfileAPIView(APIView):
                 status_code=status.HTTP_403_FORBIDDEN
             )
 
-        # 프로필 이미지 처리
+        # 프로필 이미지 처리 (S3 업로드는 save() 시점)
         if "image" in request.data:
             if request.data.get("image") == "":
                 profile.image = None
             elif request.FILES.get("image"):
                 profile.image = request.FILES["image"]
 
-        # 각 필드 업데이트
+        # 각 필드 업데이트 (메모리)
         profile.career = request.data.get("career", profile.career)
 
         role_name = request.data.get("my_role")
         if role_name:
             profile.my_role = Role.objects.filter(name=role_name).first() or profile.my_role
-
-        game_genres = request.data.getlist("game_genre")
-        if game_genres:
-            genres = GameCategory.objects.filter(name__in=game_genres)
-            profile.game_genre.set(genres)
 
         profile.tech_stack = request.data.get("tech_stack", profile.tech_stack)
         profile.purpose = request.data.get("purpose", profile.purpose)
@@ -1419,6 +1414,7 @@ class TeamBuildProfileAPIView(APIView):
         profile.title = request.data.get("title", profile.title)
         profile.content = request.data.get("content", profile.content)
 
+        # portfolio 검증 (DB/S3 변경 전)
         portfolio, error = parse_links(request.data)
         if error:
             return std_response(
@@ -1428,51 +1424,54 @@ class TeamBuildProfileAPIView(APIView):
                 status_code=status.HTTP_400_BAD_REQUEST
             )
         profile.portfolio = portfolio
-        
-        # 이미지 처리
-        # content 에서 img src 파싱
+
+        game_genres = request.data.getlist("game_genre")
+
+        # content 이미지 처리 (DB 반영은 트랜잭션, S3 반영은 커밋 후)
         old_srcs = [x.src for x in UploadImage.objects.filter(content_type=ContentType.objects.get_for_model(profile), content_id=profile.id, is_used=True)]
         new_srcs = extract_srcs(profile.content, base_url=f"{AWS_S3_BUCKET_IMAGES}/screenshot/teambuildings")
-        
-        # S3 클라이언트 불러오기
-        s3 = boto3.client(
-            's3',
-            aws_access_key_id=AWS_AUTH["aws_access_key_id"],
-            aws_secret_access_key=AWS_AUTH["aws_secret_access_key"],
-            region_name=AWS_S3_REGION_NAME,
-        )
-        
-        # 수정 이후 사라진 이미지에 대해, DB 데이터 삭제 및 S3 오브젝트 삭제 처리
         delete_srcs = set(old_srcs) - set(new_srcs)
-        if delete_srcs:
-            # DB 데이터 삭제
-            for src in delete_srcs:
-                obj = UploadImage.objects.get(src=src)
-                obj.delete()
-            # S3 오브젝트 삭제
-            s3.delete_objects(
-                Bucket=AWS_S3_BUCKET_NAME,
-                Delete={
-                    'Objects': [{'Key': urlparse(x).path.lstrip('/')} for x in delete_srcs]
-                }
-            )
-        
-        # 수정 이후 추가된 이미지에 대해 UploadImage에 데이터 추가 및 S3 오브젝트 태깅
         add_srcs = set(new_srcs) - set(old_srcs)
-        if add_srcs:
-            # DB 데이터 추가
-            _add_file_data = [
-                UploadImage(
-                    content_type=ContentType.objects.get_for_model(profile),
-                    content_id=profile.id,
-                    uploader=request.user,
-                    src=x,
-                    is_used=True
-                ) for x in add_srcs
-            ]
-            UploadImage.objects.bulk_create(_add_file_data)
-            # S3 오브젝트 태깅
-            for src in set(new_srcs) - set(old_srcs):
+
+        # ---- DB 작업은 원자적으로 처리 ----
+        with transaction.atomic():
+            # 장르 갱신
+            if game_genres:
+                profile.game_genre.set(GameCategory.objects.filter(name__in=game_genres))
+            # 사라진 이미지 DB 삭제
+            if delete_srcs:
+                UploadImage.objects.filter(src__in=delete_srcs).delete()
+            # 추가된 이미지 DB 등록
+            if add_srcs:
+                UploadImage.objects.bulk_create([
+                    UploadImage(
+                        content_type=ContentType.objects.get_for_model(profile),
+                        content_id=profile.id,
+                        uploader=request.user,
+                        src=x,
+                        is_used=True
+                    ) for x in add_srcs
+                ])
+            profile.save()
+
+        # ---- 외부 I/O: S3 (트랜잭션 커밋 후) ----
+        if delete_srcs or add_srcs:
+            s3 = boto3.client(
+                's3',
+                aws_access_key_id=AWS_AUTH["aws_access_key_id"],
+                aws_secret_access_key=AWS_AUTH["aws_secret_access_key"],
+                region_name=AWS_S3_REGION_NAME,
+            )
+            # 사라진 이미지 S3 삭제
+            if delete_srcs:
+                s3.delete_objects(
+                    Bucket=AWS_S3_BUCKET_NAME,
+                    Delete={
+                        'Objects': [{'Key': urlparse(x).path.lstrip('/')} for x in delete_srcs]
+                    }
+                )
+            # 추가된 이미지 S3 태깅
+            for src in add_srcs:
                 s3_file_key = urlparse(src).path.lstrip('/')
                 s3.put_object_tagging(
                     Bucket=AWS_S3_BUCKET_NAME,
@@ -1481,8 +1480,6 @@ class TeamBuildProfileAPIView(APIView):
                         'TagSet': [{'Key': 'is_used', 'Value': 'true'}]
                     }
                 )
-
-        profile.save()
 
         serializer = TeamBuildProfileSerializer(profile)
         return std_response(

--- a/teambuildings/views.py
+++ b/teambuildings/views.py
@@ -556,94 +556,23 @@ class TeamBuildPostDetailAPIView(APIView):
             )
         
         data = request.data
-        changes = []
 
-        # title
-        title = data.get("title", post.title)
-        if title != post.title:
-            changes.append("title")
-            post.title = title
-
-        # content
-        content = data.get("content", post.content)
-        if content != post.content:
-            changes.append("content")
-            post.content = content
-        
-            # content 에서 img src 파싱
-            old_srcs = [x.src for x in UploadImage.objects.filter(content_type=ContentType.objects.get_for_model(post), content_id=post.id, is_used=True)]
-            new_srcs = extract_srcs(post.content, base_url=f"{AWS_S3_BUCKET_IMAGES}/screenshot/teambuildings")
-            
-            # S3 클라이언트 불러오기
-            s3 = boto3.client(
-                's3',
-                aws_access_key_id=AWS_AUTH["aws_access_key_id"],
-                aws_secret_access_key=AWS_AUTH["aws_secret_access_key"],
-                region_name=AWS_S3_REGION_NAME,
-            )
-            
-            # 수정 이후 사라진 이미지에 대해, DB 데이터 삭제 및 S3 오브젝트 삭제 처리
-            delete_srcs = set(old_srcs) - set(new_srcs)
-            if delete_srcs:
-                # DB 데이터 삭제
-                for src in delete_srcs:
-                    obj = UploadImage.objects.get(src=src)
-                    obj.delete()
-                # S3 오브젝트 삭제
-                s3.delete_objects(
-                    Bucket=AWS_S3_BUCKET_NAME,
-                    Delete={
-                        'Objects': [{'Key': urlparse(x).path.lstrip('/')} for x in delete_srcs]
-                    }
+        # ---- 검증 먼저 (DB/S3 변경 전에 모두 수행) ----
+        # deadline 파싱/검증
+        deadline_raw = data.get("deadline")
+        parsed_deadline = None
+        if deadline_raw:
+            try:
+                parsed_deadline = datetime.strptime(deadline_raw, "%Y-%m-%d").date()
+            except ValueError:
+                return std_response(
+                    message="마감일은 YYYY-MM-DD 형식이어야 합니다.",
+                    status="error",
+                    error_code="CLIENT_FAIL",
+                    status_code=status.HTTP_400_BAD_REQUEST
                 )
-                
-            # 수정 이후 추가된 이미지에 대해 UploadImage에 데이터 추가 및 S3 오브젝트 태깅
-            add_srcs = set(new_srcs) - set(old_srcs)
-            if add_srcs:
-                # DB 데이터 추가
-                _add_file_data = [
-                    UploadImage(
-                        content_type=ContentType.objects.get_for_model(post),
-                        content_id=post.id,
-                        uploader=request.user,
-                        src=x,
-                        is_used=True
-                    ) for x in add_srcs
-                ]
-                UploadImage.objects.bulk_create(_add_file_data)
-                # S3 오브젝트 태깅
-                for src in add_srcs:
-                    s3_file_key = urlparse(src).path.lstrip('/')
-                    s3.put_object_tagging(
-                        Bucket=AWS_S3_BUCKET_NAME,
-                        Key=s3_file_key,
-                        Tagging={
-                            'TagSet': [{'Key': 'is_used', 'Value': 'true'}]
-                        }
-                    )
 
-        # contact
-        contact = data.get("contact", post.contact)
-        if contact != post.contact:
-            changes.append("contact")
-            post.contact = contact
-
-        # thumbnail
-        thumbnail = request.FILES.get("thumbnail", None)
-        thumbnail_basic = request.data.get("thumbnail_basic", None)
-        if thumbnail:
-            # 기존 썸네일 삭제(메인에서 활성화)
-            # if post.thumbnail:
-            #    default_storage.delete(post.thumbnail.name)
-            #    post.thumbnail.delete(save=False)
-            changes.append("thumbnail")
-            post.thumbnail = thumbnail
-        elif thumbnail_basic == "default":
-            # 기본 이미지로 설정
-            post.thumbnail.name = "images/thumbnail/teambuildings/teambuilding_default.png"
-            changes.append("thumbnail")
-
-        # 선택지 유효성 검증 (필드 변경 시만 적용)
+        # 선택지 유효성 검증 (필드 변경 시만)
         for field, choices in [("purpose", PURPOSE_CHOICES), ("duration", DURATION_CHOICES), ("meeting_type", MEETING_TYPE_CHOICES),]:
             value = data.get(field)
             if value and value != getattr(post, field):
@@ -659,26 +588,8 @@ class TeamBuildPostDetailAPIView(APIView):
                         error_code="CLIENT_FAIL",
                         status_code=status.HTTP_400_BAD_REQUEST
                     )
-                setattr(post, field, value)
-                changes.append(field)
 
-        # deadline
-        deadline = data.get("deadline")
-        if deadline:
-            try:
-                deadline = datetime.strptime(deadline, "%Y-%m-%d").date()
-                if deadline != post.deadline:
-                    post.deadline = deadline
-                    changes.append("deadline")
-            except ValueError:
-                return std_response(
-                    message="마감일은 YYYY-MM-DD 형식이어야 합니다.",
-                    status="error",
-                    error_code="CLIENT_FAIL",
-                    status_code=status.HTTP_400_BAD_REQUEST
-                )
-
-        # want_roles
+        # want_roles 검증
         raw_roles = data.getlist("want_roles", [])
         want_roles, role_error = validate_want_roles(raw_roles)
         if role_error:
@@ -688,13 +599,109 @@ class TeamBuildPostDetailAPIView(APIView):
                 error_code="CLIENT_FAIL",
                 status_code=status.HTTP_400_BAD_REQUEST
             )
-        if want_roles:
-            post.want_roles.set(Role.objects.filter(name__in=want_roles))
-            changes.append("want_roles")
 
-        # 변경사항이 있으면 저장
-        if changes:
-            post.save()
+        # content 이미지 변경 계산 (DB 반영은 트랜잭션, S3 반영은 커밋 후)
+        content = data.get("content", post.content)
+        content_changed = content != post.content
+        delete_srcs = set()
+        add_srcs = set()
+        if content_changed:
+            old_srcs = [x.src for x in UploadImage.objects.filter(content_type=ContentType.objects.get_for_model(post), content_id=post.id, is_used=True)]
+            new_srcs = extract_srcs(content, base_url=f"{AWS_S3_BUCKET_IMAGES}/screenshot/teambuildings")
+            delete_srcs = set(old_srcs) - set(new_srcs)
+            add_srcs = set(new_srcs) - set(old_srcs)
+
+        # ---- DB 작업은 원자적으로 처리 ----
+        changes = []
+        with transaction.atomic():
+            # title
+            title = data.get("title", post.title)
+            if title != post.title:
+                changes.append("title")
+                post.title = title
+
+            # content
+            if content_changed:
+                changes.append("content")
+                post.content = content
+                # 사라진 이미지 DB 삭제
+                if delete_srcs:
+                    UploadImage.objects.filter(src__in=delete_srcs).delete()
+                # 추가된 이미지 DB 등록
+                if add_srcs:
+                    UploadImage.objects.bulk_create([
+                        UploadImage(
+                            content_type=ContentType.objects.get_for_model(post),
+                            content_id=post.id,
+                            uploader=request.user,
+                            src=x,
+                            is_used=True
+                        ) for x in add_srcs
+                    ])
+
+            # contact
+            contact = data.get("contact", post.contact)
+            if contact != post.contact:
+                changes.append("contact")
+                post.contact = contact
+
+            # thumbnail
+            thumbnail = request.FILES.get("thumbnail", None)
+            thumbnail_basic = request.data.get("thumbnail_basic", None)
+            if thumbnail:
+                changes.append("thumbnail")
+                post.thumbnail = thumbnail
+            elif thumbnail_basic == "default":
+                post.thumbnail.name = "images/thumbnail/teambuildings/teambuilding_default.png"
+                changes.append("thumbnail")
+
+            # 선택지 적용 (위에서 검증 완료)
+            for field in ("purpose", "duration", "meeting_type"):
+                value = data.get(field)
+                if value and value != getattr(post, field):
+                    setattr(post, field, value)
+                    changes.append(field)
+
+            # deadline 적용
+            if parsed_deadline and parsed_deadline != post.deadline:
+                post.deadline = parsed_deadline
+                changes.append("deadline")
+
+            # want_roles 적용
+            if want_roles:
+                post.want_roles.set(Role.objects.filter(name__in=want_roles))
+                changes.append("want_roles")
+
+            # 변경사항이 있으면 저장
+            if changes:
+                post.save()
+
+        # ---- 외부 I/O: S3 (트랜잭션 커밋 후) ----
+        if delete_srcs or add_srcs:
+            s3 = boto3.client(
+                's3',
+                aws_access_key_id=AWS_AUTH["aws_access_key_id"],
+                aws_secret_access_key=AWS_AUTH["aws_secret_access_key"],
+                region_name=AWS_S3_REGION_NAME,
+            )
+            # 사라진 이미지 S3 삭제
+            if delete_srcs:
+                s3.delete_objects(
+                    Bucket=AWS_S3_BUCKET_NAME,
+                    Delete={
+                        'Objects': [{'Key': urlparse(x).path.lstrip('/')} for x in delete_srcs]
+                    }
+                )
+            # 추가된 이미지 S3 태깅
+            for src in add_srcs:
+                s3_file_key = urlparse(src).path.lstrip('/')
+                s3.put_object_tagging(
+                    Bucket=AWS_S3_BUCKET_NAME,
+                    Key=s3_file_key,
+                    Tagging={
+                        'TagSet': [{'Key': 'is_used', 'Value': 'true'}]
+                    }
+                )
 
         return std_response(
             data={

--- a/teambuildings/views.py
+++ b/teambuildings/views.py
@@ -331,62 +331,62 @@ class TeamBuildPostAPIView(APIView):
                 status_code=status.HTTP_400_BAD_REQUEST
             )
 
-        # 객체 생성
-        post = TeamBuildPost.objects.create(
-            author=user,
-            title=request.data.get("title"),
-            purpose=request.data.get("purpose"),
-            duration=request.data.get("duration"),
-            meeting_type=request.data.get("meeting_type"),
-            deadline=deadline,
-            contact=request.data.get("contact"),
-            content=request.data.get("content"),
-        )
-
-        # 썸네일 할당
-        if thumbnail:
-            post.thumbnail = thumbnail
-        elif thumbnail_basic == "default":
-            post.thumbnail.name = "images/thumbnail/teambuildings/teambuilding_default.png"
-        post.save()
-
-        # 역할 추가
-        post.want_roles.set(Role.objects.filter(name__in=want_roles))
-
-        # S3 클라이언트 불러오기
-        s3 = boto3.client(
-            's3',
-            aws_access_key_id=AWS_AUTH["aws_access_key_id"],
-            aws_secret_access_key=AWS_AUTH["aws_secret_access_key"],
-            region_name=AWS_S3_REGION_NAME,
-        )
-
-        # content 에서 img src 파싱
-        srcs = extract_srcs(post.content, base_url=f"{AWS_S3_BUCKET_IMAGES}/screenshot/teambuildings")
-        for src in srcs:
-            # DB 등록
-            UploadImage.objects.create(
-                content_type=ContentType.objects.get_for_model(post),
-                content_id=post.id,
-                uploader=user,
-                src=src,
-                is_used=True
+        # DB 작업은 원자적으로 처리 (게시글 생성 + 썸네일 + 역할 + content 이미지 DB 등록)
+        with transaction.atomic():
+            post = TeamBuildPost.objects.create(
+                author=user,
+                title=request.data.get("title"),
+                purpose=request.data.get("purpose"),
+                duration=request.data.get("duration"),
+                meeting_type=request.data.get("meeting_type"),
+                deadline=deadline,
+                contact=request.data.get("contact"),
+                content=request.data.get("content"),
             )
-            
-            # S3 태깅하기
-            s3_file_key = urlparse(src).path.lstrip('/')
-            s3.put_object_tagging(
-                Bucket=AWS_S3_BUCKET_NAME,
-                Key=s3_file_key,
-                Tagging={
-                    'TagSet': [
-                        {
-                            'Key': 'is_used',
-                            'Value': 'true'
-                        }
-                    ]
-                }
+
+            # 썸네일 할당
+            if thumbnail:
+                post.thumbnail = thumbnail
+            elif thumbnail_basic == "default":
+                post.thumbnail.name = "images/thumbnail/teambuildings/teambuilding_default.png"
+            post.save()
+
+            # 역할 추가
+            post.want_roles.set(Role.objects.filter(name__in=want_roles))
+
+            # content 에서 img src 파싱 후 DB 등록
+            srcs = extract_srcs(post.content, base_url=f"{AWS_S3_BUCKET_IMAGES}/screenshot/teambuildings")
+            for src in srcs:
+                UploadImage.objects.create(
+                    content_type=ContentType.objects.get_for_model(post),
+                    content_id=post.id,
+                    uploader=user,
+                    src=src,
+                    is_used=True
+                )
+
+        # 외부 I/O: content 이미지 S3 태깅 (트랜잭션 커밋 후)
+        if srcs:
+            s3 = boto3.client(
+                's3',
+                aws_access_key_id=AWS_AUTH["aws_access_key_id"],
+                aws_secret_access_key=AWS_AUTH["aws_secret_access_key"],
+                region_name=AWS_S3_REGION_NAME,
             )
+            for src in srcs:
+                s3_file_key = urlparse(src).path.lstrip('/')
+                s3.put_object_tagging(
+                    Bucket=AWS_S3_BUCKET_NAME,
+                    Key=s3_file_key,
+                    Tagging={
+                        'TagSet': [
+                            {
+                                'Key': 'is_used',
+                                'Value': 'true'
+                            }
+                        ]
+                    }
+                )
 
         return std_response(
             data={"post_id": post.pk},

--- a/teambuildings/views.py
+++ b/teambuildings/views.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 import boto3
 
 from django.utils import timezone
+from django.db import transaction
 from django.db.models import Q, Case, When, Value, IntegerField
 from django.core.files.storage import default_storage
 from django.core.files.images import ImageFile
@@ -721,23 +722,25 @@ class TeamBuildPostDetailAPIView(APIView):
                 status_code=status.HTTP_403_FORBIDDEN
             )
 
-        # 게시물이 삭제됨에 따라 사용된 모든 이미지에 대해, DB 데이터 삭제 및 S3 오브젝트 삭제 처리
+        # 게시물이 삭제됨에 따라 사용된 모든 이미지 src 수집 (S3 삭제는 커밋 후 수행)
         rows = UploadImage.objects.filter(content_type=ContentType.objects.get_for_model(post), content_id=post.id, is_used=True)
         srcs = [x.src for x in rows]
-        
-        if rows and srcs:
-            # DB 데이터 삭제
-            rows.delete()
-            
-            # S3 오브젝트 삭제
-            # S3 클라이언트 불러오기
+
+        # DB 작업은 원자적으로 처리 (이미지 DB 삭제 + 게시글 소프트 삭제)
+        with transaction.atomic():
+            if srcs:
+                rows.delete()
+            post.is_visible = False
+            post.save()
+
+        # 외부 I/O: S3 오브젝트 삭제 (트랜잭션 커밋 후)
+        if srcs:
             s3 = boto3.client(
                 's3',
                 aws_access_key_id=AWS_AUTH["aws_access_key_id"],
                 aws_secret_access_key=AWS_AUTH["aws_secret_access_key"],
                 region_name=AWS_S3_REGION_NAME,
             )
-            # 삭제
             s3.delete_objects(
                 Bucket=AWS_S3_BUCKET_NAME,
                 Delete={
@@ -745,10 +748,6 @@ class TeamBuildPostDetailAPIView(APIView):
                 }
             )
 
-        # 팀빌딩 게시글 소프트 삭제
-        post.is_visible = False
-        post.save()
-        
         return std_response(
             message="팀빌딩 게시글이 삭제되었습니다.",
             status="success",

--- a/teambuildings/views.py
+++ b/teambuildings/views.py
@@ -1502,23 +1502,24 @@ class TeamBuildProfileAPIView(APIView):
                 status_code=status.HTTP_403_FORBIDDEN
             )
 
-        # 게시물이 삭제됨에 따라 사용된 모든 이미지에 대해, DB 데이터 삭제 및 S3 오브젝트 삭제 처리
+        # 삭제될 이미지 src 수집 (S3 삭제는 커밋 후 수행)
         rows = UploadImage.objects.filter(content_type=ContentType.objects.get_for_model(profile), content_id=profile.id, is_used=True)
         srcs = [x.src for x in rows]
-        
-        if rows and srcs:
-            # DB 데이터 삭제
-            rows.delete()
-            
-            # S3 오브젝트 삭제
-            # S3 클라이언트 불러오기
+
+        # DB 작업은 원자적으로 처리 (이미지 DB 삭제 + 프로필 완전 삭제)
+        with transaction.atomic():
+            if srcs:
+                rows.delete()
+            profile.delete()
+
+        # 외부 I/O: S3 오브젝트 삭제 (트랜잭션 커밋 후)
+        if srcs:
             s3 = boto3.client(
                 's3',
                 aws_access_key_id=AWS_AUTH["aws_access_key_id"],
                 aws_secret_access_key=AWS_AUTH["aws_secret_access_key"],
                 region_name=AWS_S3_REGION_NAME,
             )
-            # 삭제
             s3.delete_objects(
                 Bucket=AWS_S3_BUCKET_NAME,
                 Delete={
@@ -1526,9 +1527,6 @@ class TeamBuildProfileAPIView(APIView):
                 }
             )
 
-        # 팀빌딩 프로필 완전 삭제
-        profile.delete()
-        
         return std_response(
             message="팀빌딩 프로필 삭제 완료",
             status="success",

--- a/teambuildings/views.py
+++ b/teambuildings/views.py
@@ -1161,55 +1161,57 @@ class CreateTeamBuildProfileAPIView(APIView):
                 status_code=status.HTTP_400_BAD_REQUEST
             )
 
-        # 5. 프로필 생성
-        profile = TeamBuildProfile.objects.create(
-            author=author,
-            image=profile_image,
-            career=career,
-            my_role=my_role,
-            tech_stack=tech_stack,
-            portfolio=portfolio,  # JSONField에 list 직접 저장 가능
-            purpose=purpose,
-            duration=duration,
-            meeting_type=meeting_type,
-            contact=contact,
-            title=title,
-            content=content,
-        )
-        profile.game_genre.set(game_genres)
-
-        # S3 클라이언트 불러오기
-        s3 = boto3.client(
-            's3',
-            aws_access_key_id=AWS_AUTH["aws_access_key_id"],
-            aws_secret_access_key=AWS_AUTH["aws_secret_access_key"],
-            region_name=AWS_S3_REGION_NAME,
-        )
-
-        # content 에서 img src 파싱
-        srcs = extract_srcs(profile.content, base_url=f"{AWS_S3_BUCKET_IMAGES}/screenshot/teambuildings")
-        for src in srcs:
-            UploadImage.objects.create(
-                content_type=ContentType.objects.get_for_model(profile),
-                content_id=profile.id,
-                uploader=author,
-                src=src,
-                is_used=True
+        # 5. DB 작업은 원자적으로 처리 (프로필 생성 + 장르 + content 이미지 DB 등록)
+        with transaction.atomic():
+            profile = TeamBuildProfile.objects.create(
+                author=author,
+                image=profile_image,
+                career=career,
+                my_role=my_role,
+                tech_stack=tech_stack,
+                portfolio=portfolio,  # JSONField에 list 직접 저장 가능
+                purpose=purpose,
+                duration=duration,
+                meeting_type=meeting_type,
+                contact=contact,
+                title=title,
+                content=content,
             )
+            profile.game_genre.set(game_genres)
 
-            s3_file_key = urlparse(src).path.lstrip('/')
-            s3.put_object_tagging(
-                Bucket=AWS_S3_BUCKET_NAME,
-                Key=s3_file_key,
-                Tagging={
-                    'TagSet': [
-                        {
-                            'Key': 'is_used',
-                            'Value': 'true'
-                        }
-                    ]
-                }
+            # content 에서 img src 파싱 후 DB 등록
+            srcs = extract_srcs(profile.content, base_url=f"{AWS_S3_BUCKET_IMAGES}/screenshot/teambuildings")
+            for src in srcs:
+                UploadImage.objects.create(
+                    content_type=ContentType.objects.get_for_model(profile),
+                    content_id=profile.id,
+                    uploader=author,
+                    src=src,
+                    is_used=True
+                )
+
+        # 외부 I/O: content 이미지 S3 태깅 (트랜잭션 커밋 후)
+        if srcs:
+            s3 = boto3.client(
+                's3',
+                aws_access_key_id=AWS_AUTH["aws_access_key_id"],
+                aws_secret_access_key=AWS_AUTH["aws_secret_access_key"],
+                region_name=AWS_S3_REGION_NAME,
             )
+            for src in srcs:
+                s3_file_key = urlparse(src).path.lstrip('/')
+                s3.put_object_tagging(
+                    Bucket=AWS_S3_BUCKET_NAME,
+                    Key=s3_file_key,
+                    Tagging={
+                        'TagSet': [
+                            {
+                                'Key': 'is_used',
+                                'Value': 'true'
+                            }
+                        ]
+                    }
+                )
 
         return std_response(
             data={"profile_id": profile.id},


### PR DESCRIPTION
## 1. 배경 / 목표

`teambuildings` 앱의 GET(N+1) 최적화는 앞선 브랜치(`refact/teambuildings-api-optimize`, PR #156)에서 완료해 `refact/testing`에 머지됨.
이번 작업은 로드맵 **B단계 — 쓰기(POST/PUT/DELETE) 트랜잭션 안전성 + 외부 I/O 분리**.

games 앱 쓰기 최적화 때 정립한 원칙을 그대로 적용:

1. **검증 선행** — 400을 유발하는 유효성 검증을 DB·S3 변경 **이전**으로 모은다.
2. **원자성** — 모든 DB 쓰기를 하나의 `transaction.atomic()`으로 묶는다.
3. **외부 I/O 분리** — S3 호출(`delete_objects`, `put_object_tagging`)을 트랜잭션 **커밋 후**로 뺀다.

## 2. 커밋 구성 (엔드포인트별 1커밋, 리스크 낮은 delete → post → put 순)

| # | 커밋 | 대상 | 요약 |
|---|------|------|------|
| 1 | `bc62880` | `TeamBuildPostDetailAPIView.delete` | 이미지 DB삭제 + 게시글 소프트삭제 atomic / S3 삭제 커밋 후 |
| 2 | `c5cc154` | `TeamBuildProfileAPIView.delete` | 이미지 DB삭제 + 프로필 삭제 atomic / S3 삭제 커밋 후 |
| 3 | `a660402` | `TeamBuildPostAPIView.post` | 생성+썸네일+역할+이미지DB atomic / S3 태깅 커밋 후 |
| 4 | `470fd50` | `CreateTeamBuildProfileAPIView.post` | 생성+장르+이미지DB atomic / S3 태깅 커밋 후 |
| 5 | `324f598` | `TeamBuildPostDetailAPIView.put` | 검증 선행 + atomic + S3 커밋 후 (+ 부분 반영 버그 해소) |
| 6 | `c9c0e4d` | `TeamBuildProfileAPIView.put` | 검증 선행 + atomic + S3 커밋 후 |

공통: `from django.db import transaction` import 추가.